### PR TITLE
Update link to community in page header

### DIFF
--- a/_includes/header.liquid
+++ b/_includes/header.liquid
@@ -9,7 +9,7 @@
             <li {% if base_dir[1] == 'blog' %} class="current" {% endif %}><a href="/blog">Blog</a></li>
             <li {% if base_dir[1] == 'about' %} class="current" {% endif %}><a href="/about">About</a></li>
             <li {% if base_dir[1] == 'projects' %} class="current" {% endif %}><a href="/projects">Projekte</a></li>
-            <li><a href="https://wiki.fablab-cottbus.de/" target="_blank">Wiki</a></li>
+            <li><a href="https://community.fablab-cottbus.de" target="_blank">Community</a></li>
             <li {% if base_dir[1] == 'join' %} class="current-featured" {% else %} class="featured" {% endif %}> <a style="color: #fff;" href="/join">Mitmachen</a>
 
             </li>


### PR DESCRIPTION
Instead of linking to the old Wiki, we should link to the new Discourse Community